### PR TITLE
Replace utility function dependency

### DIFF
--- a/R/credintLearner.R
+++ b/R/credintLearner.R
@@ -1,9 +1,5 @@
-#' @import BartMachine
-#' @import bayesplot
-#' @import ggplot2
 # This is a basic utility function to plot the credible intervals based on BART posterior samples.
 # Depends on the library bayesplot.
-
 credint.learner <- function(fit,
                             test = FALSE,
                             title = NULL,

--- a/R/credintLearner.R
+++ b/R/credintLearner.R
@@ -54,8 +54,13 @@ credint.learner <- function(fit,
     # Credible interval plot (bayesplot) #
     ######################################
 
-    # Order names by posterior mean
-    ord_names <- names(sort(rowMeans(weighted.post.samples), decreasing = TRUE))
+    # Order data by posterior mean
+    post_means <- rowMeans(weighted.post.samples)
+    ord_names <- names(sort(post_means, decreasing = FALSE))
+
+    # Reorder the data before plotting
+    weighted.post.samples <- weighted.post.samples[ord_names, ]
+    dataY <- dataY[ord_names]
 
     if (fit$family == "gaussian") {
       p <- mcmc_intervals(t(weighted.post.samples),
@@ -67,10 +72,9 @@ credint.learner <- function(fit,
           size = 3,
           color = "black"
         ) +
-        coord_flip() +
         labs(
           title = title,
-          x = ylab,
+          x = ylab, # coord_flip will swap x and y
           y = xlab
         ) +
         style +
@@ -80,7 +84,7 @@ credint.learner <- function(fit,
           axis.title = element_text(size = rel(size.lab)),
           axis.text = element_text(size = rel(size.axis))
         ) +
-        scale_y_discrete(limits = ord_names)
+        coord_flip() # for horizontal layout
     } else if (fit$family == "binomial") {
       p <- mcmc_intervals(t(weighted.post.samples),
         prob = prob_inner,
@@ -91,10 +95,9 @@ credint.learner <- function(fit,
           size = 3,
           color = "black"
         ) +
-        coord_flip() +
         labs(
           title = title,
-          x = ylab,
+          x = ylab, # coord_flip will swap x and y
           y = xlab
         ) +
         style +
@@ -104,7 +107,7 @@ credint.learner <- function(fit,
           axis.title = element_text(size = rel(size.lab)),
           axis.text = element_text(size = rel(size.axis))
         ) +
-        scale_y_discrete(limits = ord_names)
+        coord_flip() # for horizontal layout
     }
 
     return(p)

--- a/R/credintLearner.R
+++ b/R/credintLearner.R
@@ -1,89 +1,119 @@
+#' @import BartMachine
+#' @import bayesplot
+#' @import ggplot2
 # This is a basic utility function to plot the credible intervals based on BART posterior samples.
-# Depends on the library mcmcplots. 
+# Depends on the library bayesplot.
 
-credint.learner <- function(fit, 
+credint.learner <- function(fit,
                             test = FALSE,
+                            title = NULL,
                             ylab = NULL,
                             xlab = "Observations",
-                            cex.main = 1,
+                            size.main = 1,
                             font.main = 1,
-                            cex.lab = 1,
-                            cex.axis = 1,
-                            style = "plain",
-                            legend = c("Y=0", "Y=1"),...){
-  
+                            size.lab = 1,
+                            size.axis = 1,
+                            style = theme_bw(),
+                            prob_inner = 0.68,
+                            prob_outer = 0.95,
+                            ...) {
   ################################################
   # Extract required elements from the IL object #
   ################################################
-  
-  if(fit$base_learner =="SL.BART" & fit$meta_learner=="SL.nnls.auc"){
+
+  if (fit$base_learner == "SL.BART" & fit$meta_learner == "SL.nnls.auc") {
     weights <- fit$weights
-    
-    if(test==TRUE){
-      if(fit$test==FALSE){stop("No test set information available as part of the fit object")}
+
+    if (test == TRUE) {
+      if (fit$test == FALSE) {
+        stop("No test set information available as part of the fit object")
+      }
       dataX <- fit$X_test_layers
       dataY <- fit$Y_test
-      
-    }else{
+    } else {
       dataX <- fit$X_train_layers
-      dataY <- fit$Y_train  
+      dataY <- fit$Y_train
     }
-    
+
     #############################
     # Extract posterior samples #
     #############################
-    
+
     post.samples <- vector("list", length(weights))
     names(post.samples) <- names(dataX)
-    
-    for(i in seq_along(post.samples)){
-      post.samples[[i]] <- bart_machine_get_posterior(fit$model_fits$model_layers[[i]],dataX[[i]])$y_hat_posterior_samples
+
+    for (i in seq_along(post.samples)) {
+      post.samples[[i]] <- bart_machine_get_posterior(fit$model_fits$model_layers[[i]], dataX[[i]])$y_hat_posterior_samples
     }
-    
+
     ##################################
     # Get weighted posterior samples #
     ##################################
-    
-    weighted.post.samples <-Reduce('+', Map('*', post.samples, weights))
+
+    weighted.post.samples <- Reduce("+", Map("*", post.samples, weights))
     rownames(weighted.post.samples) <- rownames(dataX[[1]])
     names(dataY) <- rownames(dataX[[1]])
-    
+
     ######################################
-    # Credible interval plot (caterplot) #
+    # Credible interval plot (bayesplot) #
     ######################################
-    
-    pdf(file = NULL)
-    temp <- caterplot(t(weighted.post.samples),add = FALSE)
-    dev.off()
-    
-    ######################################
-    # Save the plot as ggplot and return #
-    ######################################
-    
-    if(fit$family=="gaussian"){
-      caterplot(t(weighted.post.samples),
-                horizontal = FALSE,labels.loc="fhfh",style=style,...)
-      points(dataY[temp])
-      title(main ="", xlab = xlab, ylab = ylab,
-            line = NA, outer = FALSE,cex.main=cex.main,font.main=font.main,cex.lab=cex.lab,cex.axis=cex.axis)
-      
-      p <- recordPlot()   
-    }else if(fit$family=="binomial"){
-      caterplot(t(weighted.post.samples),
-                pch = ifelse(dataY[temp]==0,4,20),
-                horizontal = FALSE,labels.loc="fhfh",style=style,
-                labels = rep("",nrow(weighted.post.samples)), ...)
-      title(main ="", xlab = xlab, ylab = ylab,
-            line = NA, outer = FALSE,cex.main=cex.main,font.main=font.main,cex.lab=cex.lab,cex.axis=cex.axis)
-      legend("bottomleft", legend=legend,
-             pch=c(4, 20), cex=0.8)
-      p <- recordPlot() 
+
+    # Order names by posterior mean
+    ord_names <- names(sort(rowMeans(weighted.post.samples), decreasing = TRUE))
+
+    if (fit$family == "gaussian") {
+      p <- mcmc_intervals(t(weighted.post.samples),
+        prob = prob_inner, # Inner probability (roughly 1 SD)
+        prob_outer = prob_outer # Outer probability (roughly 2 SD)
+      ) +
+        geom_point(aes(x = dataY[ord_names], y = ord_names),
+          shape = 1,
+          size = 3,
+          color = "black"
+        ) +
+        coord_flip() +
+        labs(
+          title = title,
+          x = ylab,
+          y = xlab
+        ) +
+        style +
+        theme(
+          axis.text.x = element_text(angle = 90, hjust = 1),
+          plot.title = element_text(size = rel(size.main)),
+          axis.title = element_text(size = rel(size.lab)),
+          axis.text = element_text(size = rel(size.axis))
+        ) +
+        scale_y_discrete(limits = ord_names)
+    } else if (fit$family == "binomial") {
+      p <- mcmc_intervals(t(weighted.post.samples),
+        prob = prob_inner,
+        prob_outer = prob_outer
+      ) +
+        geom_point(aes(x = dataY[ord_names], y = ord_names),
+          shape = ifelse(dataY[ord_names] == 0, 4, 20),
+          size = 3,
+          color = "black"
+        ) +
+        coord_flip() +
+        labs(
+          title = title,
+          x = ylab,
+          y = xlab
+        ) +
+        style +
+        theme(
+          axis.text.x = element_text(angle = 90, hjust = 1),
+          plot.title = element_text(size = rel(size.main)),
+          axis.title = element_text(size = rel(size.lab)),
+          axis.text = element_text(size = rel(size.axis))
+        ) +
+        scale_y_discrete(limits = ord_names)
     }
-  }else{
-    stop("Credible Interval feature is currently only available for 
+
+    return(p)
+  } else {
+    stop("Credible Interval feature is currently only available for
          BART as base learner and NNLS/AUC as the meta learner")
   }
-  
-  return(p)
-  
 }


### PR DESCRIPTION
Replace `mcmcplot` with better maintained `bayesplot` in utility function.

Not as clean, but produces similar functionality to original `mcmcplot::caterplot()`


